### PR TITLE
Update extension to work with snowflake.snowflake-vsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "pl/sql"
   ],
   "activationEvents": [
-    "onLanguage:sql"
+    "onLanguage:snowflake-sql"
   ],
   "contributes": {
     "configuration": {

--- a/src/extension.js
+++ b/src/extension.js
@@ -24,7 +24,7 @@ const getConfig = ({ insertSpaces, tabSize }) => ({
 const format = (text, config) => sqlFormatter.format(text, config);
 
 module.exports.activate = () =>
-	vscode.languages.registerDocumentRangeFormattingEditProvider('sql', {
+	vscode.languages.registerDocumentRangeFormattingEditProvider('snowflake-sql', {
 		provideDocumentRangeFormattingEdits: (document, range, options) => [
 			vscode.TextEdit.replace(range, format(document.getText(range), getConfig(options)))
 		]


### PR DESCRIPTION
This change updates the tracked language for the formatter to work with the official `snowflake.snowflake-vsc` extension. 